### PR TITLE
Forget clean text password after registration

### DIFF
--- a/bin/createaccount.rb
+++ b/bin/createaccount.rb
@@ -68,6 +68,10 @@ db.query("SELECT id, username, password, email, gender
 			if retval.include? retcode['message'] then
 				send_mail( email, username, retcode['status'], retcode['message'] )
 				db.query("UPDATE tmw_accounts SET STATE = #{retcode['final_state']} WHERE id = #{id}")
+
+				if (retcode['status'] == :SUCCESS) then
+					db.query("UPDATE tmw_accounts SET password = '' WHERE id = #{id}")
+				end
 			end
 		end
 	rescue


### PR DESCRIPTION
Currently all passwords stay in the db for ever.
This now deletes no longer required passwords.

Please also run `DELETE FROM tmw_accounts WHERE STATE = 1;`
