### PR TITLE
[sh-version] Forget clean text password after registration

### DIFF
--- a/bin/create_account.sh
+++ b/bin/create_account.sh
@@ -74,15 +74,14 @@ frob_accounts()
         if grep -q 'successfully created' <<< "$RESULT"
         then
             send_email 'Your account was created successfully. Have fun playing The Mana World!'
-            do_mysql << __EOF__
-update $SQL_TABLE set state = 1 where id = $ID
-__EOF__
+            STATE=1
         else
             send_email $'Something went wrong when automatically creating your account.\nError message:' "$RESULT"
-            do_mysql << __EOF__
-update $SQL_TABLE set state = 2 where id = $ID
-__EOF__
+            STATE=2
         fi
+        do_mysql << __EOF__
+update $SQL_TABLE set state = $STATE, password = '' where id = $ID
+__EOF__
     done
 }
 


### PR DESCRIPTION
Currently all passwords stay in the db for ever.
This now deletes no longer required passwords.

Please also run `DELETE FROM tmw_accounts WHERE STATE = 1;`
