### PR TITLE
index.html: Change Freenode into Libera Chat

### DIFF
--- a/public/lite/index.html
+++ b/public/lite/index.html
@@ -41,7 +41,7 @@
 			</blockquote>
 			<h3>Contact us</h3>
 			<ul>
-				<li>On IRC: <a href="https://forums.themanaworld.org/viewforum.php?f=41">#themanaworld on Freenode</a></li>
+				<li>On IRC: <a href="https://forums.themanaworld.org/viewforum.php?f=41">#themanaworld on Libera Chat</a></li>
 				<li>On Discord: <a href="https://forums.themanaworld.org/viewforum.php?f=65">The Mana World server</a></li>
 				<li>On the forums: <a href="https://forums.themanaworld.org/viewforum.php?f=3">Support and Bug reports</a></li>
 			</ul>


### PR DESCRIPTION
The channels were moved (https://www.themanaworld.org/news#94-news-2021-05-28). This updates the outdated information.
The Libera Chat webchat, which the link is redirecting to, is also using "Libera Chat", so I used this instead of Libera.Chat.